### PR TITLE
Fix some Clippy lints; migrate to new hbbft API.

### DIFF
--- a/src/bin/peer_node.rs
+++ b/src/bin/peer_node.rs
@@ -104,9 +104,9 @@ impl Transaction {
 fn main() {
     env_logger::Builder::new()
         .format(|buf, record| {
-            write!(
+            writeln!(
                 buf,
-                "{} [{}]: {}\n",
+                "{} [{}]: {}",
                 Local::now().format("%Y-%m-%dT%H:%M:%S"),
                 record.level(),
                 record.args()

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -133,7 +133,7 @@ impl Block {
 
     /// Returns this block's hash.
     pub fn hash(&self) -> Option<Sha256Hash> {
-        self.hash.clone()
+        self.hash
     }
 
     /// Returns this block's hash.

--- a/src/hydrabadger/handler.rs
+++ b/src/hydrabadger/handler.rs
@@ -514,7 +514,7 @@ impl<T: Contribution> Handler<T> {
             }
             State::AwaitingMorePeersForKeyGeneration { .. } => {
                 // info!("Removing peer ({}: '{}') from await list.",
-                //     src_out_addr, src_uid.clone().unwrap());
+                //     src_out_addr, src_uid.unwrap());
                 // state.peer_connection_dropped(&*self.hdb.peers());
             }
             State::GeneratingKeys { .. } => {
@@ -575,7 +575,7 @@ impl<T: Contribution> Handler<T> {
                     .unwrap()
                     .tx()
                     .unbounded_send(WireMessage::welcome_received_change_add(
-                        self.hdb.uid().clone(),
+                        *self.hdb.uid(),
                         self.hdb.secret_key().public_key(),
                         net_state,
                     ))
@@ -613,7 +613,7 @@ impl<T: Contribution> Handler<T> {
             }
 
             InternalMessageKind::PeerDisconnect => {
-                let dropped_src_uid = src_uid.clone().unwrap();
+                let dropped_src_uid = src_uid.unwrap();
                 info!(
                     "Peer disconnected: ({}: '{}').",
                     src_out_addr, dropped_src_uid
@@ -637,7 +637,7 @@ impl<T: Contribution> Handler<T> {
                     match peers
                         .establish_validator(src_out_addr, (src_uid_new, src_in_addr, src_pk))
                     {
-                        true => debug_assert!(src_uid_new == src_uid.clone().unwrap()),
+                        true => debug_assert!(src_uid_new == src_uid.unwrap()),
                         false => debug_assert!(src_uid.is_none()),
                     }
 
@@ -648,7 +648,7 @@ impl<T: Contribution> Handler<T> {
                 // New outgoing connection:
                 WireMessageKind::WelcomeReceivedChangeAdd(src_uid_new, src_pk, net_state) => {
                     debug!("Received NetworkState: \n{:?}", net_state);
-                    assert!(src_uid_new == src_uid.clone().unwrap());
+                    assert!(src_uid_new == src_uid.unwrap());
                     let mut peers = self.hdb.peers_mut();
 
                     // Set new (outgoing-connection) peer's public info:
@@ -691,7 +691,7 @@ impl<T: Contribution> Handler<T> {
                     self.handle_join_plan(jp, state, &peers)?;
                 }
 
-                wm @ _ => warn!(
+                wm => warn!(
                     "hydrabadger::Handler::handle_internal_message: Unhandled wire message: \
                      \n{:?}",
                     wm,

--- a/src/hydrabadger/state.rs
+++ b/src/hydrabadger/state.rs
@@ -398,11 +398,11 @@ impl<T: Contribution> State<T> {
             State::GeneratingKeys { .. } => {
                 panic!("FIXME: RESTART KEY GENERATION PROCESS AFTER PEER DISCONNECTS.");
             }
-            State::Observer { dhb: _, .. } => {
+            State::Observer { .. } => {
                 debug!("Ignoring peer disconnection when `State::Observer`.");
                 return;
             }
-            State::Validator { dhb: _, .. } => {
+            State::Validator { .. } => {
                 debug!("Ignoring peer disconnection when `State::Validator`.");
                 return;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #![cfg_attr(feature = "nightly", feature(alloc_system))]
 #![cfg_attr(feature = "nightly", feature(proc_macro))]
+#![cfg_attr(feature = "cargo-clippy",
+            allow(large_enum_variant, new_without_default_derive, expect_fun_call, or_fun_call,
+                  useless_format, cyclomatic_complexity, needless_pass_by_value, module_inception,
+                  match_bool))]
 
 #[cfg(feature = "nightly")]
 extern crate alloc_system;
@@ -63,7 +67,7 @@ use hbbft::{
     crypto::{PublicKey, PublicKeySet},
     dynamic_honey_badger::{JoinPlan, Message as DhbMessage, DynamicHoneyBadger, Input as DhbInput},
     sync_key_gen::{Ack, Part},
-    Step as MessagingStep,
+    DaStep as MessagingStep,
     Contribution as HbbftContribution,
 };
 


### PR DESCRIPTION
This fixes the build with the modified hbbft `Step` type, and addresses
some uncontroversial Clippy warnings. Other Clippy lints are disabled.