### PR TITLE
Modify `WireMessages` to use peer public key.

### DIFF
--- a/src/hydrabadger/hydrabadger.rs
+++ b/src/hydrabadger/hydrabadger.rs
@@ -314,7 +314,7 @@ impl<T: Contribution> Hydrabadger<T> {
     /// Returns a future that handles incoming connections on `socket`.
     fn handle_incoming(self, socket: TcpStream) -> impl Future<Item = (), Error = ()> {
         info!("Incoming connection from '{}'", socket.peer_addr().unwrap());
-        let wire_msgs = WireMessages::new(socket, self.inner.secret_key.clone());
+        let wire_msgs = WireMessages::new(socket, self.inner.secret_key.clone(), self.clone());
 
         wire_msgs
             .into_future()
@@ -382,7 +382,7 @@ impl<T: Contribution> Hydrabadger<T> {
             .and_then(move |socket| {
                 let local_pk = local_sk.public_key();
                 // Wrap the socket with the frame delimiter and codec:
-                let mut wire_msgs = WireMessages::new(socket, local_sk);
+                let mut wire_msgs = WireMessages::new(socket, local_sk, self.clone());
                 let wire_hello_result = wire_msgs.send_msg(WireMessage::hello_request_change_add(
                     uid, in_addr, local_pk,
                 ));

--- a/src/hydrabadger/mod.rs
+++ b/src/hydrabadger/mod.rs
@@ -26,6 +26,8 @@ pub enum InputOrMessage<T> {
     Message(Uid, Message),
 }
 
+// TODO: Move this up to `lib.rs` or, preferably, create another error type
+// for general (lib) use.
 #[derive(Debug, Fail)]
 pub enum Error {
     #[fail(display = "Io error: {}", _0)]
@@ -50,8 +52,8 @@ pub enum Error {
     VoteForNotValidator,
     #[fail(display = "Unable to transmit epoch status to listener, listener receiver dropped")]
     InstantiateHbListenerDropped,
-    #[fail(display = "Received duplicate HelloRequestChangeAdd messages")]
-    DuplicateHello,
+    #[fail(display = "Message received from unknown peer")]
+    MessageReceivedUnknownPeer,
 }
 
 impl From<std::io::Error> for Error {


### PR DESCRIPTION
`WireMessages` keeps a `Hydrabadger` ref and looks up the peer's public key in the `Peers` map.

Currently only `Message` variants (which are HB messages) are verified. I think those are the only ones we'll need to check but we'll see.

Closes #14.