### PR TITLE
Initialize the epoch for a joining node.

### DIFF
--- a/src/hydrabadger/handler.rs
+++ b/src/hydrabadger/handler.rs
@@ -360,6 +360,8 @@ impl<T: Contribution> Handler<T> {
                             self.hdb.config(),
                             &self.step_queue,
                         )?);
+                        let (era, epoch) = state.dhb().unwrap().epoch();
+                        self.hdb.set_current_epoch(era + epoch);
                     }
                     None => {
                         iom_queue_opt = Some(state.set_validator(


### PR DESCRIPTION
A joining node currently expects to start in epoch 0 and panics. This initializes it to the correct epoch, although it's pretty ugly; we should probably just expose the epoch number from the `JoinPlan` itself and use that instead.

Closes #17.