### PR TITLE
Fix a debug message for a `State::set_observer ` operation

### DIFF
--- a/src/hydrabadger/state.rs
+++ b/src/hydrabadger/state.rs
@@ -234,7 +234,7 @@ impl<C: Contribution, N: NodeId> StateMachine<C, N> {
                 State::Observer { dhb: Some(dhb) }
             }
             ref s => panic!(
-                "State::set_observer: State must be `GeneratingKeys`. \
+                "State::set_observer: State must be `DeterminingNetworkState`. \
                  State: {}",
                 s.discriminant()
             ),


### PR DESCRIPTION
`GeneratingKeys` is not a valid state for the `State::set_observer` operation.